### PR TITLE
Treat no-underscore-dangle as an error

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -203,7 +203,7 @@ module.exports = {
     "no-spaced-func": 0,              // disallow space between function identifier and application
     "no-ternary": 0,                  // disallow the use of ternary operators (off by default)
     "no-trailing-spaces": 0,          // disallow trailing whitespace at the end of lines
-    "no-underscore-dangle": 0,        // disallow dangling underscores in identifiers
+    "no-underscore-dangle": 2,        // disallow dangling underscores in identifiers
     "one-var": 0,                     // allow just one var statement per function (off by default)
     "operator-assignment": 0,         // require assignment operator shorthand where possible or prohibit it entirely (off by default)
     "operator-linebreak": 0,          // enforce operators to be placed before or after line breaks (off by default)


### PR DESCRIPTION
Disallows dangling underscores.

The following patterns are considered errors:

```js
var foo_;
var __proto__ = {};
foo._bar();
```

The following patterns are not errors:

```js
var _ = require('underscore');
var obj = _.contains(items, item);
obj.__proto__ = {};
var file = __filename;
```