### PR TITLE
Update eslintrc.js

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -77,7 +77,7 @@ module.exports = {
     "no-negated-in-lhs": 2,                     // disallow negation of the left operand of an in expression
     "no-obj-calls": 2,                          // disallow the use of object properties of the global object (Math and JSON) as functions
     "no-regex-spaces": 2,                       // disallow multiple spaces in a regular expression literal
-    "no-reserved-keys": 2,                      // disallow reserved words being used as object literal keys (off by default)
+    "no-reserved-keys": 0,                      // disallow reserved words being used as object literal keys (off by default)
     "no-sparse-arrays": 2,                      // disallow sparse arrays
     "no-unreachable": 2,                        // disallow unreachable statements after a return, throw, continue, or break statement
     "use-isnan": 2,                             // disallow comparisons with the value NaN


### PR DESCRIPTION
Turn off no-reserved-keys as it's a non-issue in ES5+. See: http://eslint.org/docs/rules/no-reserved-keys.html

I see this error occur as a result of having this turned on:

`Line 1: no-reserved-keys - Rule 'no-reserved-keys' was removed and replaced by: quote-props`