### PR TITLE
Add character limit warning at 80 chars.

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -241,7 +241,7 @@ module.exports = {
     ////////// Legacy //////////
 
     "max-depth": 0,       // specify the maximum depth that blocks can be nested (off by default)
-    "max-len": 0,         // specify the maximum length of a line in your program (off by default)
+    "max-len": [1, 80, 2], // specify the maximum length of a line in your program (off by default)
     "max-params": 0,      // limits the number of parameters that can be used in the function declaration. (off by default)
     "max-statements": 0,  // specify the maximum number of statement allowed in a function (off by default)
     "no-bitwise": 0,      // disallow use of bitwise operators (off by default)


### PR DESCRIPTION
Turn on warning for lines of code over 80 characters.
Treats tabs as 2 spaces.