### PR TITLE
Disable consistent-return

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -102,7 +102,7 @@ module.exports = {
     "accessor-pairs": 0,        // enforces getter/setter pairs in objects (off by default)
     "block-scoped-var": 2,      // treat var statements as if they were block scoped (off by default)
     "complexity": 0,            // specify the maximum cyclomatic complexity allowed in a program (off by default)
-    "consistent-return": 2,     // require return statements to either always or never specify values
+    "consistent-return": 0,     // require return statements to either always or never specify values
     "curly": [2, "multi-line"], // Single-line no curlys; multiline requires curly
     "default-case": 2,          // require default case in switch statements (off by default)
     "dot-notation": 0,          // encourages use of dot notation whenever possible


### PR DESCRIPTION
Causing too many errors on async callback functions that should not be
affected by inconsistent returns.